### PR TITLE
Correct SLEEP_15Ms to SLEEP_15MS

### DIFF
--- a/LowPower.h
+++ b/LowPower.h
@@ -3,7 +3,7 @@
 
 enum period_t
 {
-	SLEEP_15Ms,
+	SLEEP_15MS,
 	SLEEP_30MS,	
 	SLEEP_60MS,
 	SLEEP_120MS,


### PR DESCRIPTION
Correct SLEEP_15Ms to SLEEP_15MS to match documentation.