### PR TITLE
Updated 15Ms to 15MS

### DIFF
--- a/LowPower.h
+++ b/LowPower.h
@@ -3,7 +3,7 @@
 
 enum period_t
 {
-	SLEEP_15Ms,
+	SLEEP_15MS,
 	SLEEP_30MS,	
 	SLEEP_60MS,
 	SLEEP_120MS,


### PR DESCRIPTION
Updated to match other examples.