### PR TITLE
Added support for ATmega256RFR2

### DIFF
--- a/Examples/idleWakePeriodic/idleWakePeriodic.ino
+++ b/Examples/idleWakePeriodic/idleWakePeriodic.ino
@@ -25,6 +25,11 @@ void loop()
   //		  TIMER2_OFF, TIMER1_OFF, TIMER0_OFF, SPI_OFF, USART3_OFF, 
   //		  USART2_OFF, USART1_OFF, USART0_OFF, TWI_OFF);
 
+  // ATmega256RFR2
+  //LowPower.idle(SLEEP_8S, ADC_OFF, TIMER5_OFF, TIMER4_OFF, TIMER3_OFF, 
+  //      TIMER2_OFF, TIMER1_OFF, TIMER0_OFF, SPI_OFF,
+  //      USART1_OFF, USART0_OFF, TWI_OFF);
+
   // Do something here
   // Example: Read sensor, data logging, data transmission.
 }

--- a/LowPower.cpp
+++ b/LowPower.cpp
@@ -468,6 +468,82 @@ void	LowPowerClass::idle(period_t period, adc_t adc, timer5_t timer5,
 }
 #endif
 
+#if defined (__AVR_ATmega256RFR2__)
+void	LowPowerClass::idle(period_t period, adc_t adc, timer5_t timer5, 
+					                timer4_t timer4, timer3_t timer3, timer2_t timer2, 
+													timer1_t timer1, timer0_t timer0, spi_t spi, 
+													usart1_t usart1, 
+			                    usart0_t usart0, twi_t twi)
+{
+	// Temporary clock source variable 
+	unsigned char clockSource = 0;
+	
+	if (timer2 == TIMER2_OFF)
+	{
+		if (TCCR2B & CS22) clockSource |= (1 << CS22);
+		if (TCCR2B & CS21) clockSource |= (1 << CS21);
+		if (TCCR2B & CS20) clockSource |= (1 << CS20);
+	
+		// Remove the clock source to shutdown Timer2
+		TCCR2B &= ~(1 << CS22);
+		TCCR2B &= ~(1 << CS21);
+		TCCR2B &= ~(1 << CS20);
+		
+		power_timer2_disable();
+	}
+	
+	if (adc == ADC_OFF)	
+	{
+		ADCSRA &= ~(1 << ADEN);
+		power_adc_disable();
+	}
+	
+	if (timer5 == TIMER5_OFF)	power_timer5_disable();	
+	if (timer4 == TIMER4_OFF)	power_timer4_disable();	
+	if (timer3 == TIMER3_OFF)	power_timer3_disable();	
+	if (timer1 == TIMER1_OFF)	power_timer1_disable();	
+	if (timer0 == TIMER0_OFF)	power_timer0_disable();	
+	if (spi == SPI_OFF)			  power_spi_disable();
+	if (usart1 == USART1_OFF)	power_usart1_disable();
+	if (usart0 == USART0_OFF)	power_usart0_disable();
+	if (twi == TWI_OFF)			  power_twi_disable();
+	
+	if (period != SLEEP_FOREVER)
+	{
+		wdt_enable(period);
+		WDTCSR |= (1 << WDIE);	
+	}
+	
+	lowPowerBodOn(SLEEP_MODE_IDLE);
+	
+	if (adc == ADC_OFF)
+	{
+		power_adc_enable();
+		ADCSRA |= (1 << ADEN);
+	}
+	
+	if (timer2 == TIMER2_OFF)
+	{
+		if (clockSource & CS22) TCCR2B |= (1 << CS22);
+		if (clockSource & CS21) TCCR2B |= (1 << CS21);
+		if (clockSource & CS20) TCCR2B |= (1 << CS20);
+		
+		power_timer2_enable();
+	}
+
+	if (timer5 == TIMER5_OFF)	power_timer5_enable();	
+	if (timer4 == TIMER4_OFF)	power_timer4_enable();		
+	if (timer3 == TIMER3_OFF)	power_timer3_enable();	
+	if (timer1 == TIMER1_OFF)	power_timer1_enable();	
+	if (timer0 == TIMER0_OFF)	power_timer0_enable();	
+	if (spi == SPI_OFF)			  power_spi_enable();
+	if (usart1 == USART1_OFF)	power_usart1_enable();
+	if (usart0 == USART0_OFF)	power_usart0_enable();
+	if (twi == TWI_OFF)			  power_twi_enable();
+}
+#endif
+
+
 /*******************************************************************************
 * Name: adcNoiseReduction
 * Description: Putting microcontroller into ADC noise reduction state. This is

--- a/LowPower.h
+++ b/LowPower.h
@@ -113,11 +113,17 @@ class LowPowerClass
 			void	idle(period_t period, adc_t adc, timer2_t timer2, 
 								 timer1_t timer1, timer0_t timer0, spi_t spi,
 					       usart0_t usart0, twi_t twi);
-		#elif defined __AVR_ATmega2560__
+		#elif defined (__AVR_ATmega2560__)
 			void	idle(period_t period, adc_t adc, timer5_t timer5, 
 								 timer4_t timer4, timer3_t timer3, timer2_t timer2,
 			   				 timer1_t timer1, timer0_t timer0, spi_t spi,
 					       usart3_t usart3, usart2_t usart2, usart1_t usart1, 
+								 usart0_t usart0, twi_t twi);
+		#elif defined (__AVR_ATmega256RFR2__)
+			void	idle(period_t period, adc_t adc, timer5_t timer5, 
+								 timer4_t timer4, timer3_t timer3, timer2_t timer2,
+			   				 timer1_t timer1, timer0_t timer0, spi_t spi,
+					       usart1_t usart1, 
 								 usart0_t usart0, twi_t twi);
 		#elif defined __AVR_ATmega32U4__	
 			void	idle(period_t period, adc_t adc, timer4_t timer4, timer3_t timer3, 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Devices Supported:
 * ATMega328P
 * ATMega32U4
 * ATMega2560
+* ATMega256RFR2
 * ATSAMD21G18A
 
 ####Notes:


### PR DESCRIPTION
Updated library for supporting ATmega256RFR2.

- Updated library
- Updated idleWakePeriodic adding ATmega256RFR2 example line
- Updated devices supported in README.md

I tested the library with the Altair board from http://www.aquila.io/en
