### PR TITLE
Add missing macros to support Arduino168. Ref code by rocketscream

### DIFF
--- a/LowPower.cpp
+++ b/LowPower.cpp
@@ -103,6 +103,14 @@ do { 						\
 		#define power_timer4_enable()		(PRR1 &= (uint8_t)~(1 << PRTIM4))							
 	#endif
 #endif
+
+//Add missing macros for Arduino168 (ref github issue #14)
+#if defined __AVR_ATmega168__
+	#ifndef SLEEP_MODE_EXT_STANDBY
+		#define SLEEP_MODE_EXT_STANDBY (0x07<<1)
+	#endif
+#endif
+
   
 /*******************************************************************************
 * Name: idle


### PR DESCRIPTION
Hi,

I have applied the conditional macro definition to support Arduino168. Successfully tested with generic Arduino168 clone - using 8 second sleep timer and noted significant reduced power consumption while device is sleeping (multimeter milliamp test).

I would like this merged because there are loads of really cheap 168 clones available that make great battery powered projects. These would surely benefit from this excellent library.

Thanks,
Kev.