### PR TITLE
Pullup all unused pins to minimize power consumption.

### DIFF
--- a/Examples/idleWakePeriodic/idleWakePeriodic.ino
+++ b/Examples/idleWakePeriodic/idleWakePeriodic.ino
@@ -3,7 +3,7 @@
 
 void setup()
 {
-  // No setup is required for this library
+  LowPower.pullupAllPins(); // This should appear before any calls to pinMode
 }
 
 void loop() 
@@ -33,4 +33,3 @@ void loop()
   // Do something here
   // Example: Read sensor, data logging, data transmission.
 }
-

--- a/Examples/powerDownWakeExternalInterrupt/powerDownWakeExternalInterrupt.ino
+++ b/Examples/powerDownWakeExternalInterrupt/powerDownWakeExternalInterrupt.ino
@@ -11,6 +11,7 @@ void wakeUp()
 
 void setup()
 {
+    LowPower.pullupAllPins(); // This should appear before any calls to pinMode
     // Configure wake up pin as input.
     // This will consumes few uA of current.
     pinMode(wakeUpPin, INPUT);   

--- a/Examples/powerDownWakePeriodic/powerDownWakePeriodic.ino
+++ b/Examples/powerDownWakePeriodic/powerDownWakePeriodic.ino
@@ -3,7 +3,7 @@
 
 void setup()
 {
-    // No setup is required for this library
+    LowPower.pullupAllPins(); // This should appear before any calls to pinMode
 }
 
 void loop() 

--- a/Examples/standbyExternalInterruptSAMD21/standbyExternalInterruptSAMD21.ino
+++ b/Examples/standbyExternalInterruptSAMD21/standbyExternalInterruptSAMD21.ino
@@ -7,6 +7,8 @@ unsigned char count = 10;
 
 void setup()
 {
+  LowPower.pullupAllPins(); // This should appear before any calls to pinMode
+  
 	// Wait for serial USB port to open
 	while(!SerialUSB);
 	SerialUSB.println("***** ATSAMD21 Standby Mode Example *****");

--- a/LowPower.cpp
+++ b/LowPower.cpp
@@ -238,7 +238,7 @@ void	LowPowerClass::idle(period_t period, adc_t adc, timer2_t timer2,
 * 1. NIL
 *
 *******************************************************************************/
-void	pullupAllPins()
+void	LowPowerClass::pullupAllPins()
 {
 	for (uint8_t i = 0; i < 23; i++)
 	{
@@ -367,7 +367,7 @@ void	LowPowerClass::idle(period_t period, adc_t adc,
 * 1. NIL
 *
 *******************************************************************************/
-void	pullupAllPins()
+void	LowPowerClass::pullupAllPins()
 {
 	for (uint8_t i = 0; i < 26; i++)
 	{
@@ -514,7 +514,7 @@ void	LowPowerClass::idle(period_t period, adc_t adc, timer2_t timer2,
 * 1. NIL
 *
 *******************************************************************************/
-void	pullupAllPins()
+void	LowPowerClass::pullupAllPins()
 {
 	for (uint8_t i = 0; i < 32; i++)
 	{
@@ -694,7 +694,7 @@ void	LowPowerClass::idle(period_t period, adc_t adc, timer5_t timer5,
 * 1. NIL
 *
 *******************************************************************************/
-void	pullupAllPins()
+void	LowPowerClass::pullupAllPins()
 {
 	for (uint8_t i = 0; i < 86; i++)
 	{
@@ -863,7 +863,7 @@ void	LowPowerClass::idle(period_t period, adc_t adc, timer5_t timer5,
 * 1. NIL
 *
 *******************************************************************************/
-void	pullupAllPins()
+void	LowPowerClass::pullupAllPins()
 {
 	for (uint8_t i = 0; i < 38; i++)
 	{

--- a/LowPower.cpp
+++ b/LowPower.cpp
@@ -222,6 +222,30 @@ void	LowPowerClass::idle(period_t period, adc_t adc, timer2_t timer2,
 	if (usart0 == USART0_OFF)	power_usart0_enable();
 	if (twi == TWI_OFF)			power_twi_enable();
 }
+
+/*******************************************************************************
+* Name: pullupAllPins
+* Description: If some pins are unused, it is recommended to ensure
+* that these pins have a defined level. Even though most of the digital
+* inputs are disabled in the deep sleep mode floating inputs should be
+* avoided to reduce current consumption in all other modes where the
+* digital inputs are enabled (reset, active mode and idle mode).The
+* simplest method to ensure a defined level of an unused pin, is to
+* enable the internal pull-up. 
+*
+* Argument  	Description
+* =========  	===========
+* 1. NIL
+*
+*******************************************************************************/
+void	pullupAllPins()
+{
+	for (uint8_t i = 0; i < 23; i++)
+	{
+		pinMode(i, INPUT_PULLUP);
+	}
+	
+}
 #endif
 
 /*******************************************************************************
@@ -326,6 +350,30 @@ void	LowPowerClass::idle(period_t period, adc_t adc,
 	if (usart1 == USART1_OFF)	power_usart1_enable();
 	if (twi == TWI_OFF)			power_twi_enable();
 	if (usb == USB_OFF)			power_usb_enable();
+}
+
+/*******************************************************************************
+* Name: pullupAllPins
+* Description: If some pins are unused, it is recommended to ensure
+* that these pins have a defined level. Even though most of the digital
+* inputs are disabled in the deep sleep mode floating inputs should be
+* avoided to reduce current consumption in all other modes where the
+* digital inputs are enabled (reset, active mode and idle mode).The
+* simplest method to ensure a defined level of an unused pin, is to
+* enable the internal pull-up. 
+*
+* Argument  	Description
+* =========  	===========
+* 1. NIL
+*
+*******************************************************************************/
+void	pullupAllPins()
+{
+	for (uint8_t i = 0; i < 26; i++)
+	{
+		pinMode(i, INPUT_PULLUP);
+	}
+	
 }
 #endif
 
@@ -448,6 +496,31 @@ void	LowPowerClass::idle(period_t period, adc_t adc, timer2_t timer2,
 	if (usart1 == USART1_OFF)	power_usart1_enable();
 	if (usart0 == USART0_OFF)	power_usart0_enable();
 	if (twi == TWI_OFF)			power_twi_enable();
+}
+
+
+/*******************************************************************************
+* Name: pullupAllPins
+* Description: If some pins are unused, it is recommended to ensure
+* that these pins have a defined level. Even though most of the digital
+* inputs are disabled in the deep sleep mode floating inputs should be
+* avoided to reduce current consumption in all other modes where the
+* digital inputs are enabled (reset, active mode and idle mode).The
+* simplest method to ensure a defined level of an unused pin, is to
+* enable the internal pull-up. 
+*
+* Argument  	Description
+* =========  	===========
+* 1. NIL
+*
+*******************************************************************************/
+void	pullupAllPins()
+{
+	for (uint8_t i = 0; i < 32; i++)
+	{
+		pinMode(i, INPUT_PULLUP);
+	}
+	
 }
 #endif
 
@@ -605,6 +678,30 @@ void	LowPowerClass::idle(period_t period, adc_t adc, timer5_t timer5,
 	if (usart0 == USART0_OFF)	power_usart0_enable();
 	if (twi == TWI_OFF)			power_twi_enable();
 }
+
+/*******************************************************************************
+* Name: pullupAllPins
+* Description: If some pins are unused, it is recommended to ensure
+* that these pins have a defined level. Even though most of the digital
+* inputs are disabled in the deep sleep mode floating inputs should be
+* avoided to reduce current consumption in all other modes where the
+* digital inputs are enabled (reset, active mode and idle mode).The
+* simplest method to ensure a defined level of an unused pin, is to
+* enable the internal pull-up. 
+*
+* Argument  	Description
+* =========  	===========
+* 1. NIL
+*
+*******************************************************************************/
+void	pullupAllPins()
+{
+	for (uint8_t i = 0; i < 86; i++)
+	{
+		pinMode(i, INPUT_PULLUP);
+	}
+	
+}
 #endif
 
 /*******************************************************************************
@@ -748,6 +845,31 @@ void	LowPowerClass::idle(period_t period, adc_t adc, timer5_t timer5,
 	if (usart1 == USART1_OFF)	power_usart1_enable();
 	if (usart0 == USART0_OFF)	power_usart0_enable();
 	if (twi == TWI_OFF)			  power_twi_enable();
+}
+
+
+/*******************************************************************************
+* Name: pullupAllPins
+* Description: If some pins are unused, it is recommended to ensure
+* that these pins have a defined level. Even though most of the digital
+* inputs are disabled in the deep sleep mode floating inputs should be
+* avoided to reduce current consumption in all other modes where the
+* digital inputs are enabled (reset, active mode and idle mode).The
+* simplest method to ensure a defined level of an unused pin, is to
+* enable the internal pull-up. 
+*
+* Argument  	Description
+* =========  	===========
+* 1. NIL
+*
+*******************************************************************************/
+void	pullupAllPins()
+{
+	for (uint8_t i = 0; i < 38; i++)
+	{
+		pinMode(i, INPUT_PULLUP);
+	}
+	
 }
 #endif
 

--- a/LowPower.h
+++ b/LowPower.h
@@ -152,6 +152,7 @@ class LowPowerClass
 			void	powerSave(period_t period, adc_t adc, bod_t bod, timer2_t timer2) __attribute__((optimize("-O1")));
 			void	powerStandby(period_t period, adc_t adc, bod_t bod) __attribute__((optimize("-O1")));
 			void	powerExtStandby(period_t period, adc_t adc, bod_t bod, timer2_t timer2) __attribute__((optimize("-O1")));
+			void	pullupAllPins();
 
 		#elif defined (__arm__)
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -16,7 +16,8 @@ powerDown	KEYWORD2
 powerSave	KEYWORD2
 powerStandby	KEYWORD2
 powerExtStandby	KEYWORD2
-standby	KEYWORD2
+standby		KEYWORD2
+pullupAllPins	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
**11.2.6 Unconnected Pins**
If some pins are unused, it is recommended to ensure that these pins have a defined level. Eventhough most of the digital inputs are disabled in the deep sleep modes as described above, floating inputs should be avoided to reduce current consumption in all other modes where the digitalinputs are enabled (Reset, Active mode and Idle mode).The simplest method to ensure a defined level of an unused pin, is to enable the internal pull-up.In this case, the pull-up will be disabled during reset. If low power consumption during reset isimportant, it is recommended to use an external pull-up or pull-down. Connecting unused pinsdirectly to VCC or GND is not recommended, since this may cause excessive currents if the pin isaccidentally configured as an output