### PR TITLE
Update version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Low-Power
-version=1.6
+version=1.81
 author=Rocket Scream Electronics
 maintainer=Rocket Scream Electronics
 sentence=Lightweight power management library


### PR DESCRIPTION
PlatformIO will not notice an update to the library as long as the version of this library is still stuck at 1.6 (although in Github release pages you released 1.81).

Will resolve the issues people have with this library in PlatformIO (https://community.platformio.org/t/outdated-low-power-library/23838)